### PR TITLE
Add Pixel Caffeine for new Facebook Ads category

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Inspired by [awesome](https://github.com/sindresorhus/awesome) and [awesome-php]
 		- [Widget] (#widget)		
 		- [Move and Backup] (#move-and-backup)
 		- [Marketing] (#marketing)
+		- [Facebook Ads] (#facebook-ads)
 	- [Commandline] (#commandline)
 	- [Resources](#resources)
 		- [Classes](#classes)
@@ -154,6 +155,10 @@ Inspired by [awesome](https://github.com/sindresorhus/awesome) and [awesome-php]
 #### Marketing
 * [Leads] (https://wordpress.org/support/plugin/leads/) - Provides in-depth visitor tracking and list collection + segmentation tools.
 * [Calls to Action] (https://wordpress.org/support/plugin/cta/) - Provides template powered ad placement system for calls to action, sponsored adverts, and data collection efforts. 
+
+
+#### Facebook Ads
+* [Pixel Caffeine] (https://wordpress.org/support/plugin/pixel-caffeine/) - The simplest and easiest way to manage your Facebook Pixel needs and create laser focused custom audiences on WordPress.
 
 ## Commandline
 


### PR DESCRIPTION
This is my new plugin I developed. It is totally 100%, without any purchase in plugin for advanced features, and it helps to add the Facebook Pixel in own WordPress site and mainly create custom audiences inside WordPress admin directly. 

It is a good tool for who work with Facebook Ads and for retargeting! :)

See https://wordpress.org/plugins/pixel-caffeine/ for full feature list.

I hope it is good for your list. :)