### PR TITLE
Remove www.wpchat.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,6 @@ Inspired by [awesome](https://github.com/sindresorhus/awesome) and [awesome-php]
 * [Nacin](http://nacin.com/) - WordPress Lead Developer
 * [Konstantin Kovshenin](http://kovshenin.com/) - WordPress, Automattic and Open Source
 * [Automattic](http://automattic.com/) - We are the people behind WordPress.com, which serves more than 15.8 billion pages a month, as well as a host of other popular services, such as Akismet, Jetpack, and VaultPress.  We are strong believers in Open Source, and the vast majority of our work is available under licenses like the GPL.
-* [WPChat](http://www.wpchat.com) - Popular Forum for WordPress discussion.
 * [WordPress Tavern](https://wptavern.com/) - WPTavern has news and a weekly podcast on Wordpress and its ecosystem.
 * [Quora](https://www.quora.com/topic/WordPress) - Q&A in Quora for Wordpress users and developers.
 * [Wordpress subreddit](https://www.reddit.com/r/Wordpress/) - Subreddit for news, articles and discussion regarding WordPress. For advanced users try the [ProWordpress subreddit](https://www.reddit.com/r/ProWordPress/)


### PR DESCRIPTION
The website is inactive for more than an year, so it is safe to remove it from the list.
Issue: https://github.com/miziomon/awesome-wordpress/issues/55