### PR TITLE
Add WP Multitool to Performance plugins section

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Inspired by [awesome](https://github.com/sindresorhus/awesome) and [awesome-php]
 * [P3](https://wordpress.org/plugins/p3-profiler/) - This plugin creates a profile of your WordPress site's plugins' performance by measuring their impact on your site's load time.  Often times, WordPress sites load slowly because of poorly configured plugins or because there are so many of them. By using the P3 plugin, you can narrow down anything causing slowness on your site.
 * [Plugin Load Filter](https://wordpress.org/plugins/plugin-load-filter/) - Although have installed a lot of plugins, if you do not want to activate for all of the pages, you will be able to deactivate unnecessary plugins of each individual page. Through the filter activation of plugins, you can speed up the display response.
 * [Autoptimize](https://wordpress.org/plugins/autoptimize/) - Autoptimize is an effective performance tool that speeds up a website by optimizing JS, CSS, images (incl. lazy-load), HTML and Google Fonts, asyncing JS, removing emoji cruft and more.
-* [WP Multitool](https://wpmultitool.com) - AI-powered WordPress performance toolkit. Identifies slow database queries with AI analysis, manages bulk plugin/theme updates, and exports/imports wp-config.php settings. Zero bloat modular architecture.
+* [WP Multitool](https://wpmultitool.com) - WordPress performance toolkit for developers. Identifies slow database queries, manages bulk plugin/theme updates, and exports/imports wp-config.php settings. Modular zero-bloat architecture.
 
 #### E-commerce
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Inspired by [awesome](https://github.com/sindresorhus/awesome) and [awesome-php]
 * [P3](https://wordpress.org/plugins/p3-profiler/) - This plugin creates a profile of your WordPress site's plugins' performance by measuring their impact on your site's load time.  Often times, WordPress sites load slowly because of poorly configured plugins or because there are so many of them. By using the P3 plugin, you can narrow down anything causing slowness on your site.
 * [Plugin Load Filter](https://wordpress.org/plugins/plugin-load-filter/) - Although have installed a lot of plugins, if you do not want to activate for all of the pages, you will be able to deactivate unnecessary plugins of each individual page. Through the filter activation of plugins, you can speed up the display response.
 * [Autoptimize](https://wordpress.org/plugins/autoptimize/) - Autoptimize is an effective performance tool that speeds up a website by optimizing JS, CSS, images (incl. lazy-load), HTML and Google Fonts, asyncing JS, removing emoji cruft and more.
+* [WP Multitool](https://wpmultitool.com) - AI-powered WordPress performance toolkit. Identifies slow database queries with AI analysis, manages bulk plugin/theme updates, and exports/imports wp-config.php settings. Zero bloat modular architecture.
 
 #### E-commerce
 


### PR DESCRIPTION
## What's added

[WP Multitool](https://wpmultitool.com) — WordPress performance and developer toolkit (14 modules).

**Why it fits the Performance section:**
- Slow Query Analyzer: MySQL EXPLAIN analysis, health scores, and ready-to-run CREATE INDEX suggestions (fully local, no external APIs)
- Find Slow Callbacks: profiles action/filter hook performance
- Frontend Optimizer, Database Optimizer, Autoloader Optimizer
- Config Manager: GUI for wp-config.php constants
- Modular architecture — disabled modules = zero overhead
